### PR TITLE
Added Healthcheck to dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,6 +4,9 @@ RUN apk --no-cache --no-progress upgrade && \
     apk --no-cache --no-progress --repository http://dl-3.alpinelinux.org/alpine/edge/testing/ --allow-untrusted add dante-server && \
     rm -rf /tmp/*
 
+HEALTHCHECK --interval=5m --timeout=20s --start-period=1m \
+  CMD if test $( curl -m 10 -s https://api.nordvpn.com/vpn/check/full | jq -r '.["status"]' ) = "Protected" ; then exit 0; else nordvpn connect ${CONNECT} ; exit $?; fi
+
 COPY sockd.conf /etc/sockd.conf
 COPY start.sh .
 RUN chmod 777 start.sh

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ RUN apk --no-cache --no-progress upgrade && \
     rm -rf /tmp/*
 
 HEALTHCHECK --interval=5m --timeout=20s --start-period=1m \
-  CMD if test $( curl -m 10 -s https://api.nordvpn.com/vpn/check/full | jq -r '.["status"]' ) = "Protected" ; then exit 0; else nordvpn connect ${CONNECT} ; exit $?; fi
+  CMD if test $( curl -m 10 -s https://api.nordvpn.com/vpn/check/full | jq -r \'.["status"]\' ) = "Protected" ; then exit 0; else exit 1; fi
 
 COPY sockd.conf /etc/sockd.conf
 COPY start.sh .


### PR DESCRIPTION
This PR adds the Healthcheck from the base image (https://github.com/bubuntux/nordvpn) to ensure that the container is functioning properly in a verifiable state. 