### PR TITLE
Update start.sh to fix container

### DIFF
--- a/start.sh
+++ b/start.sh
@@ -2,7 +2,7 @@
 
 set -e
 
-/usr/bin/nordVpn.sh > /dev/stdout 2> /dev/stdout &
+/usr/bin/nordVpn > /dev/stdout 2> /dev/stdout &
 
 while true; do
   if [ "$(ip tuntap)" = "" ]; then


### PR DESCRIPTION
Recently, the container broke with an error message `/start.sh: line 5: /usr/bin/nordVpn.sh: No such file or directory`. This is potentially due to something upstream changing that I cannot fully determine. The `nordVpn.sh` file has been replaced with a `nordVpn` executable. The PR modifies the start.sh to use this new file.
